### PR TITLE
Use .lintr file for default lintr configuration

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,4 @@
+linters: with_defaults(
+    trailing_whitespace_linter=NULL,
+    line_length_linter=lintr::line_length_linter(80))
+    

--- a/tests/testthat/test_lint_package.R
+++ b/tests/testthat/test_lint_package.R
@@ -2,9 +2,7 @@ context("Lint package to verify code style")
 
 
 test_that("code conforms to the style guide", {
-  lint_errs <- lintr::lint_package(linters=lintr::with_defaults(
-    trailing_whitespace_linter=NULL,
-    line_length_linter=lintr::line_length_linter(80)))
+  lint_errs <- lintr::lint_package()
   
   lint_err_info <- ""
   trim.leading <- function (x)  sub("^\\s+", "", x)


### PR DESCRIPTION
Just pulls out the configuration for `lintr` into a configuration file. Not too beneficial now, but will be easier to add files to exclude from linting using the `.lintr` file. You'll probably want to exclude the JS files used in htmlwidgets, since those won't follow R code style.
