### PR TITLE
Update Travis CI config to install dependencies for radial phylograms

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,4 @@
 ^\.Rproj\.user$
 ^\.travis\.yml$
 travis/
+^.lintr$

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,24 @@ warnings_are_errors: true
 
 sudo: required
 
+virtualenv:
+  - system_site_packages: true
+
 env:
   global:
     - CRAN: http://cran.rstudio.com
+    - BIOC_USE_DEVEL = "FALSE"
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libcurl4-openssl-dev libxml2-dev python python-setuptools python-dev python-numpy
+  - sudo easy_install -f http://biopython.org/DIST/ biopython
 
 r_binary_packages:
   - testthat
+  
+r_github_packages:
+  - jimhester/lintr
 
 before_script: Rscript ./travis/travis_prep.R
 
@@ -26,3 +38,4 @@ branches:
   only:
     - master
     - dev
+    - travis

--- a/travis/travis_prep.R
+++ b/travis/travis_prep.R
@@ -1,2 +1,3 @@
 devtools::install_github('jimhester/lintr')
-
+source("http://bioconductor.org/biocLite.R")
+biocLite("muscle")


### PR DESCRIPTION
This installs Biopython, the Bioconductor package `muscle`, and the GitHub version of `lintr` to the Travis system before running the build check. The build will fail without `muscle`, and possibly without the latest version of `lintr` from GitHub since that allows you to exclude lines from linting (which you have done).
