### PR TITLE
Fix falsely reporting some numbers as not positive in pca_plot

### DIFF
--- a/R/arg_validation.R
+++ b/R/arg_validation.R
@@ -71,7 +71,8 @@ validate_num_data <- function(d) {
 validate_pos_num <- function(n) {
   lapply(1:length(n), 
          function(i) {
-           if (class(n[[i]]) != "numeric" || length(n[[i]]) > 1) {
+           if (!(class(n[[i]]) %in% c("numeric", "integer")) || 
+               length(n[[i]]) > 1) {
              err <- paste0("The argument '", names(n)[[i]],
                            "' must be a positive integer", collapse="")
              stop(err, call.=FALSE)


### PR DESCRIPTION
The arg validation was only checking for `"numeric`" not `"integer`". So this was happening:

``` R
> pca_plot(iris[, 1:4], iris_cluster, num_clust=iris_cluster[['k_best']])
Error: The argument 'num_clust' must be a positive integer
```
