### PR TITLE
Fix check for boolean data in arg_validation.R

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,4 +1,6 @@
 linters: with_defaults(
     trailing_whitespace_linter=NULL,
-    line_length_linter=lintr::line_length_linter(80))
+    line_length_linter=lintr::line_length_linter(80),
+    infix_spaces_linter=NULL,
+    spaces_left_parentheses_linter=NULL)
 exclusions: list("R/NbClust.R")

--- a/R/arg_validation.R
+++ b/R/arg_validation.R
@@ -76,7 +76,6 @@ is_boolean <- function(d) {
 #' confirm.
 #' @keywords internal
 validate_num_data <- function(d) {
-  boolean_warning <- NULL
   classes <- c("data.frame", "matrix")
   types <- c("numeric", "integer")
   if (!(class(d) %in% classes)) {
@@ -89,15 +88,12 @@ validate_num_data <- function(d) {
                    call.=FALSE) 
             } else TRUE
           })
-  lapply(d,
-          function(x) {
-            uniq <- unique(x)
-            if (all(uniq %in% 0:1)) {
-              boolean_warning <- TRUE  # nolint
-            }
-  })
-  if (!is.null(boolean_warning)) {
-    message("At least one column of 'd' contains only values 0 and 1.")
+  for (col in d) {
+    uniq <- unique(col)
+    if (all(uniq %in% 0:1)) {
+      message("At least one column of 'd' contains only values 0 and 1.")
+      break
+    }
   }
 }
 


### PR DESCRIPTION
This PR changes how `validate_num_data` checks for boolean columns.
- It uses a `for` loop to go through columns of the _data.frame_.
- It moves the message to within the conditional in the `for` loop.
- It adds a `break` in the `for` loop after the message.

The previous method wasn't outputting the boolean warning message on some machines.
