### PR TITLE
Use NbClust package to determine best number of clusters

### DIFF
--- a/R/NbClust.R
+++ b/R/NbClust.R
@@ -102,7 +102,6 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     nn <- numberObsAfter <- dim(jeu)[1]
     pp <- dim(jeu)[2]
     TT <- t(jeu) %*% jeu
-    # I think that this is where the singularity issues reside. tryCatch it.
     sizeEigenTT <- length(eigen(TT)[["values"]])
     eigenValues <- eigen(TT / (nn - 1))[["values"]]
     
@@ -609,7 +608,6 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     return(results)
   }
   
-  # other part to incorporate tryCatch?
   ################ # ccc, scott, marriot, trcovw, tracew, friedman and rubin # #
 
   Indices.WBT <- function(x, cl, P, s, vv) {
@@ -637,7 +635,13 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     else {
       message("Error: division by zero!")
     }
-    friedman <- sum(diag(solve(W) * B))
+    friedman <- tryCatch({
+      sum(diag(solve(W) * B))
+    }, 
+    error = function(e) {
+      NA
+    }
+    )
     rubin <- sum(diag(P)) / sum(diag(W))
     R2 <- 1 - sum(diag(W)) / sum(diag(P))
     v1 <- 1
@@ -669,8 +673,6 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
   }
   
   ################################## # Kl, Ch, Hartigan, Ratkowsky and Ball # #
-
-  # tryCatch when this function is called?
   
   Indices.Traces <- function(data, d, clall, index = "all") {
     x <- data
@@ -1149,7 +1151,6 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
   }
   
   ################ 
-  # tryCatch possibility below?
   
   for (nc in min_nc:max_nc) {
     if (any(method == 1) || (method == 2) || (method == 3) || (method == 4) || 

--- a/R/NbClust.R
+++ b/R/NbClust.R
@@ -122,7 +122,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
       }
       s1 <- sqrt(eigenValues)
       ss <- rep(1, sizeEigenTT)
-      if (indef) {
+      if (exists("indef")) {
         vv <- NA
       } else {
         for (i in 1:sizeEigenTT) {
@@ -661,7 +661,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     u <- s / c
     k1 <- sum((u >= 1) == TRUE)
     p1 <- min(k1, qq - 1)
-    if (indef) {
+    if (exists("indef")) {
       ccc <- NA
     } else if (all(p1 > 0, p1 < pp)) {
       for (i in 1:p1)

--- a/R/NbClust.R
+++ b/R/NbClust.R
@@ -113,9 +113,9 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
       (indice == 32))) {
       for (i in 1:sizeEigenTT) {
         if (eigenValues[i] < 0) {
-          message("The TSS matrix is indefinite. There must be too many ", 
+          warning("The TSS matrix is indefinite. There must be too many ", 
           "missing values. The following indices cannot be calculated:\n", 
-          "CCC, Scott, Marriot, Friedman, and Ratkowsky")
+          "CCC, Scott, Marriot, Friedman, and Ratkowsky", call. = FALSE)
           indef <- TRUE
           break
         }

--- a/R/NbClust.R
+++ b/R/NbClust.R
@@ -128,11 +128,15 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
       }
       s1 <- sqrt(eigenValues)
       ss <- rep(1, sizeEigenTT)
-      for (i in 1:sizeEigenTT) {
-        if (s1[i] != 0) 
-          ss[i] <- s1[i]
+      if (indef) {
+        vv <- NA
+      } else {
+        for (i in 1:sizeEigenTT) {
+          if (s1[i] != 0) 
+            ss[i] <- s1[i]
+        }
+        vv <- prod(ss)
       }
-      vv <- prod(ss)
     }
   }
   
@@ -636,7 +640,11 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     xbar <- solve(t(z) %*% z) %*% t(z) %*% x
     B <- t(xbar) %*% t(z) %*% z %*% xbar
     W <- P - B
-    marriot <- (qq ^ 2) * det(W)
+    if (det(W) != 0) {
+      marriot <- (qq ^ 2) * det(W)
+    } else {
+      marriot <- NA
+    }
     trcovw <- sum(diag(cov(W)))
     tracew <- sum(diag(W))
     if (det(W) != 0) 

--- a/R/NbClust.R
+++ b/R/NbClust.R
@@ -1492,7 +1492,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
         }
       },
       error = function(e) {
-        next
+        found <- FALSE
       }
       )
     }

--- a/R/NbClust.R
+++ b/R/NbClust.R
@@ -667,7 +667,9 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     u <- s / c
     k1 <- sum((u >= 1) == TRUE)
     p1 <- min(k1, qq - 1)
-    if (all(p1 > 0, p1 < pp)) {
+    if (indef) {
+      ccc <- NA
+    } else if (all(p1 > 0, p1 < pp)) {
       for (i in 1:p1)
         v1 <- v1 * s[i]
       c <- (v1 / qq) ^ (1 / p1)

--- a/R/NbClust.R
+++ b/R/NbClust.R
@@ -41,7 +41,7 @@
 #' @keywords internal
 NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
                     min.nc = 2, max.nc = 15, method = NULL, index = "all",
-                    alphaBeale = 0.1, plots = FALSE) {
+                    alphaBeale = 0.1, plots = TRUE) {
   x <- 0
   min_nc <- min.nc
   max_nc <- max.nc
@@ -72,7 +72,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
       (indice == 32)) {
     if ((max.nc - min.nc) < 2) 
       stop("The difference between the minimum and the maximum number of", 
-           "clusters must be at least equal to 2", call. = FALSE)
+        "clusters must be at least equal to 2", call. = FALSE)
   }
   
   if (is.null(data)) {
@@ -80,22 +80,20 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
       stop("\n", "method = kmeans, data matrix is needed", call. = FALSE)
     } else {
       if ((indice == 1) || (indice == 2) || (indice == 3) || (indice == 4) || 
-          (indice == 5) || (indice == 6) || (indice == 7) || (indice == 8) || 
-          (indice == 9) || (indice == 10) || (indice == 12) || (indice == 14) || 
-          (indice == 15) || (indice == 16) || (indice == 17) ||
-          (indice == 18) || (indice == 19) || (indice == 20) ||
-          (indice == 23) || (indice == 24) || (indice == 25) ||
-          (indice == 27) || (indice == 28) || (indice == 29) ||
-          (indice == 30) || (indice == 31) || (indice == 32))
+        (indice == 5) || (indice == 6) || (indice == 7) || (indice == 8) || 
+        (indice == 9) || (indice == 10) || (indice == 12) || (indice == 14) || 
+        (indice == 15) || (indice == 16) || (indice == 17) || (indice == 
+        18) || (indice == 19) || (indice == 20) || (indice == 23) || (indice == 
+        24) || (indice == 25) || (indice == 27) || (indice == 28) || (indice == 
+        29) || (indice == 30) || (indice == 31) || (indice == 32)) 
         stop("\n", "Data matrix is needed. Only frey, mcclain, cindex, ", 
-             "sihouette and dunn can be computed.", "\n", call. = FALSE)
+          "sihouette and dunn can be computed.", "\n", call. = FALSE)
       
       if (is.null(diss)) 
         stop("data matrix and dissimilarity matrix are both null",
              call. = FALSE)
       else message("\n", "Only frey, mcclain, cindex, sihouette and dunn can ", 
-                   "be computed. To compute the other indices, data matrix is ",
-                   "needed\n")
+        "be computed. To compute the other indices, data matrix is needed\n")
     }
   }
   
@@ -107,19 +105,19 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     nn <- numberObsAfter <- dim(jeu)[1]
     pp <- dim(jeu)[2]
     TT <- t(jeu) %*% jeu
-    sizeEigenTT <- length(eigen(TT)[["values"]])
-    eigenValues <- eigen(TT / (nn - 1))[["values"]]
+    sizeEigenTT <- length(eigen(TT)[["value"]])
+    eigenValues <- eigen(TT / (nn - 1))[["value"]]
     
     # Only for indices using vv : CCC, Scott, marriot, tracecovw, tracew,
     # friedman, rubin
     
     if (any((indice == 4) || (indice == 5) || (indice == 6) || (indice == 7) || 
-            (indice == 8) || (indice == 9) || (indice == 10) ||
-            (indice == 31) || (indice == 32))) {
+      (indice == 8) || (indice == 9) || (indice == 10) || (indice == 31) || 
+      (indice == 32))) {
       for (i in 1:sizeEigenTT) {
         if (eigenValues[i] < 0) {
           stop("The TSS matrix is indefinite. There must be too many missing ", 
-               "values. The index cannot be calculated.", call. = FALSE)
+          "values. The index cannot be calculated.", call. = FALSE)
         }
       }
       s1 <- sqrt(eigenValues)
@@ -149,10 +147,10 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
   if (is.null(diss)) {
     if (distanceM == 1) {
       md <- dist(jeu, method = "euclidean") # dist function computes and returns
-      # the distance matrix computed by
-      # using the specified distance
-      # measure to compute the distances
-      # between the rows of a data matrix.
+                                            # the distance matrix computed by
+                                            # using the specified distance
+                                            # measure to compute the distances
+                                            # between the rows of a data matrix.
     }
     if (distanceM == 2) {
       md <- dist(jeu, method = "maximum")
@@ -172,11 +170,6 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     if (distanceM == 7) {
       stop("dissimilarity matrix and distance are both NULL", call. = FALSE)
     }
-    
-    if (distanceM == 7) 
-    {		  
-      stop("dissimilarity matrix and distance are both NULL")		
-    } 
   }
   if (!is.null(diss)) {
     if ((distanceM == 1) || (distanceM == 2) || (distanceM == 3) ||
@@ -188,7 +181,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
   # &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&# #
   # Methods # #
   # &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&#
-  
+
   res <- array(0, c(max_nc - min_nc + 1, 30))
   x_axis <- min_nc:max_nc
   resCritical <- array(0, c(max_nc - min_nc + 1, 4))
@@ -216,19 +209,19 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     hc <- hclust(md, method = "complete")
   }
   if (method == 4) {
-    hc<-hclust(md,method = "average")
+    hc <- hclust(md, method = "average")
   }
   if (method == 5) {
-    hc<-hclust(md,method = "mcquitty")
+    hc <- hclust(md, method = "mcquitty")
   }
   if (method == 6) {
-    hc<-hclust(md,method = "median")
+    hc <- hclust(md, method = "median")
   }
   if (method == 7) {
-    hc<-hclust(md,method = "centroid")
+    hc <- hclust(md, method = "centroid")
   }
   if (method == 9) {
-    hc<-hclust(md,method = "ward.D")
+    hc <- hclust(md, method = "ward.D")
   }
   
   # &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&# #
@@ -238,7 +231,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
   ############################## # SD and SDbw # #
   
   
-  centers<-function(cl,x) {
+  centers <- function(cl, x) {
     x <- as.matrix(x)
     n <- length(cl)
     k <- max(cl)
@@ -264,14 +257,14 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
       for (j in 1:ncol(x)) {
         for (i in 1:n) {
           if (cl[i] == u) 
-            variance.clusters[u, j] <- (variance.clusters[u, j] +
-                                          (x[i, j] - centers.matrix[u, j]) ^ 2)
+          variance.clusters[u, j] <- (variance.clusters[u, j] + (x[i, j] - 
+            centers.matrix[u, j]) ^ 2)
         }
       }            
     }
     for (u in 1:k) {
-      for (j in 1:ncol(x)) 
-        variance.clusters[u, j] <- variance.clusters[u, j] / cluster.size[u]
+      for (j in 1:ncol(x)) variance.clusters[u, j] <- variance.clusters[u, 
+        j] / cluster.size[u]
     }
     variance.matrix <- numeric(0)
     for (j in 1:ncol(x)) variance.matrix[j] <- var(x[, j]) * (n - 1) / n
@@ -291,14 +284,15 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     return(scat)
   }
   
-  density.clusters<-function(cl, x) {
+  density.clusters<-function(cl, x)
+  {
     x <- as.matrix(x)
     k <- max(cl)
     n <- length(cl)
     distance <- matrix(0, ncol = 1, nrow = n)
     density <- matrix(0, ncol = 1, nrow = k)
     centers.matrix <- centers(cl, x)
-    stdev <- Average.scattering(cl, x)[["stdev"]]
+    stdev <- Average.scattering(cl, x)[["stdev "]]
     for (i in 1:n) {
       u <- 1
       while (cl[i] != u) u <- u + 1
@@ -313,7 +307,9 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     return(dens)
   }
   
-  density.bw<-function(cl, x) {
+  
+  density.bw<-function(cl, x)
+  {
     x <- as.matrix(x)
     k <- max(cl)
     n <- length(cl)
@@ -327,15 +323,15 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
           distance <- matrix(0, ncol = 1, nrow = n)
           moy <- (centers.matrix[u, ] + centers.matrix[v, ]) / 2
           for (i in 1:n) {
-            if ((cl[i] == u) || (cl[i] == v)) {
-              for (j in 1:ncol(x)) {
-                distance[i] <- distance[i] + (x[i, j] - moy[j]) ^ 2
-              }
-              distance[i] <- sqrt(distance[i])
-              if (distance[i] <= stdev) {
-                density.bw[u, v] <- density.bw[u, v] + 1
-              }
+          if ((cl[i] == u) || (cl[i] == v)) {
+            for (j in 1:ncol(x)) {
+            distance[i] <- distance[i] + (x[i, j] - moy[j]) ^ 2
             }
+            distance[i] <- sqrt(distance[i])
+            if (distance[i] <= stdev) {
+            density.bw[u, v] <- density.bw[u, v] + 1
+            }
+          }
           }
         }
       }
@@ -373,7 +369,9 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
   
   ################################## # Hubert index # #
   
-  Index.Hubert<-function(x, cl) {
+  Index.Hubert<-function(x, cl)
+  {
+    
     k <- max(cl)
     n<-dim(x)[1]
     y <- matrix(0, ncol = dim(x)[2], nrow = n)
@@ -410,12 +408,12 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
   
   ################################## # Gamma, Gplus and Tau # #
   
-  Index.sPlussMoins <- function (cl1,md) {
+  Index.sPlussMoins <- function (cl1,md)
+  {
     cn1 <- max(cl1)
     n1 <- length(cl1)
     dmat <- as.matrix(md)
-    average.distance <- median.distance <- separation <- numeric(0)
-      cluster.size <- within.dist1 <- between.dist1 <- numeric(0)
+    average.distance <- median.distance <- separation <- cluster.size <- within.dist1 <- between.dist1 <- numeric(0)
     separation.matrix <- matrix(0, ncol = cn1, nrow = cn1)
     di <- list()
     for (u in 1:cn1) {
@@ -430,8 +428,8 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
           suv <- dmat[cl1 == u, cl1 == v]
           bv <- c(bv, suv)
           if (u < v) {
-            separation.matrix[u, v] <- separation.matrix[v, u] <- min(suv)
-            between.dist1 <- c(between.dist1, suv)
+          separation.matrix[u, v] <- separation.matrix[v, u] <- min(suv)
+          between.dist1 <- c(between.dist1, suv)
           }
         }
       }
@@ -465,13 +463,18 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     cluster.size <- within.dist1 <- between.dist1 <- numeric(0)
     separation.matrix <- matrix(0, ncol = cn1, nrow = cn1)
     di <- list()
-    for (u in 1:cn1) {
+    for (u in 1:cn1) 
+    {
       cluster.size[u] <- sum(cl1 == u)
       du <- as.dist(dmat[cl1 == u, cl1 == u])
       within.dist1 <- c(within.dist1, du)
+      #average.distance[u] <- mean(du)
+      #median.distance[u] <- median(du)
+      #bv <- numeric(0)
       for (v in 1:cn1) {
         if (v != u) {
           suv <- dmat[cl1 == u, cl1 == v]
+          #bv <- c(bv, suv)
           if (u < v) {
             separation.matrix[u, v] <- separation.matrix[v, u] <- min(suv)
             between.dist1 <- c(between.dist1, suv)
@@ -490,6 +493,8 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
       cluster.size[w] <- sum(cl2 == w)
       dw <- as.dist(dmat[cl2 == w, cl2 == w])
       within.dist2 <- c(within.dist2, dw)
+      #average.distance[w] <- mean(dw)
+      #median.distance[w] <- median(dw)
       bx <- numeric(0)
       for (x in 1:cn2) {
         if (x != w) {
@@ -515,7 +520,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
   }
   
   ################################## # Point-biserial # #
-  
+
   Indice.ptbiserial <- function (x,md,cl1)
   {
     nn <- dim(x)[1]
@@ -570,7 +575,8 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
   
   Indices.WKWL <- function(x, cl1 = cl1, cl2 = cl2) {
     dim2 <- dim(x)[2]
-    wss <- function(x) {
+    wss <- function(x) 
+    {
       x <- as.matrix(x)
       n <- length(x)
       centers <- matrix(nrow = 1, ncol = ncol(x))
@@ -619,13 +625,14 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     pseudot2 <- BKL / ((WK + WL) / (NK + NL - 2))
     beale <- (BKL / (WK + WL)) / (((NM - 1) / (NM - 2)) * (2 ^ (2 / dim2) - 1))
     results <- list(duda = duda, pseudot2 = pseudot2, NM = NM, NK = NK, NL = NL,
-                    beale = beale)
+      beale = beale)
     return(results)
   }
   
   ################ # ccc, scott, marriot, trcovw, tracew, friedman and rubin # #
-  
-  Indices.WBT <- function(x, cl, P, s, vv) {
+
+  Indices.WBT <- function(x, cl, P, s, vv) 
+  {
     n <- dim(x)[1]
     pp <- dim(x)[2]
     qq <- max(cl)
@@ -644,7 +651,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     trcovw <- sum(diag(cov(W)))
     tracew <- sum(diag(W))
     if (det(W) != 0) 
-      scott <- n * log(det(P) / det(W))
+      scott <- n * log(det(P) / det(W)) 
     else {
       message("Error: division by zero!")
     }
@@ -679,7 +686,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
   }
   
   ################################## # Kl, Ch, Hartigan, Ratkowsky and Ball # #
-  
+
   Indices.Traces <- function(data, d, clall, index = "all") 
   {
     x <- data
@@ -779,9 +786,9 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
       m <- ncol(x)
       g <- k <- max(clall[, 2])
       KL <- abs((g - 1) ^ (2 / m) * gss(x, clall[, 1], d)[["wgss"]] -
-                  g ^ (2 / m) * gss(x, clall[, 2], d)[["wgss"]]) /
+                g ^ (2 / m) * gss(x, clall[, 2], d)[["wgss"]]) /
         abs((g) ^ (2 / m) * gss(x, clall[, 2], d)[["wgss"]] -
-              (g + 1) ^ (2 / m) * gss(x, clall[, 3], d)[["wgss"]])
+            (g + 1) ^ (2 / m) * gss(x, clall[, 3], d)[["wgss"]])
       return(KL)
     }
     
@@ -822,7 +829,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
       n <- nrow(x)
       g <- max(clall[, 1])
       HART <- (gss(x, clall[, 2], d)[["wgss"]] /
-                 gss(x, clall[, 3], d)[["wgss"]] - 1) * (n - g - 1)
+               gss(x, clall[, 3], d)[["wgss"]] - 1) * (n - g - 1)
       return(HART)
     }
     
@@ -961,14 +968,14 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
         Sil <- 0
         for (i in 1:length(cl)) {
           if (cl[i] == k) {
-            ai <- sum(d[i, cl == k]) / (sum(cl == k) - 1)
-            dips <- NULL
-            for (j in 1:max(cl)) if (cl[i] != j) 
-              if (sum(cl == j) != 1) 
-                dips <- cbind(dips, c((sum(d[i, cl == j])) / (sum(cl == j))))
+          ai <- sum(d[i, cl == k]) / (sum(cl == k) - 1)
+          dips <- NULL
+          for (j in 1:max(cl)) if (cl[i] != j) 
+            if (sum(cl == j) != 1) 
+              dips <- cbind(dips, c((sum(d[i, cl == j])) / (sum(cl == j))))
             else dips <- cbind(dips, c((sum(d[i, cl == j]))))
-            bi <- min(dips)
-            Sil <- Sil + (bi - ai) / max(c(ai, bi))
+          bi <- min(dips)
+          Sil <- Sil + (bi - ai) / max(c(ai, bi))
           }
         }
       }
@@ -1037,10 +1044,10 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
             for (zz in (1:ClassNr)) {
               Xuse <- X[pp == zz, ]
               Wk0 <- Wk0 + sum(diag(var(Xuse))) * (length(pp[pp == zz]) - 
-                                                     1) / (dim(X)[1] - ClassNr)
-              Xuse2 <- Xnew[pp2 == zz, ]
-              WkB[1, bb] <- WkB[1, bb] + sum(diag(var(Xuse2))) *
-                (length(pp2[pp2 == zz]) - 1) / (dim(X)[1] - ClassNr)
+                1) / (dim(X)[1] - ClassNr)
+            Xuse2 <- Xnew[pp2 == zz, ]
+            WkB[1, bb] <- WkB[1, bb] + sum(diag(var(Xuse2))) *
+              (length(pp2[pp2 == zz]) - 1) / (dim(X)[1] - ClassNr)
             }
           }
           if (ClassNr == 1) {
@@ -1068,7 +1075,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
             }
           }
           if (ClassNr == 1) {
-            WkB[1, bb] <- sum(diag(var(Xnew)))
+          WkB[1, bb] <- sum(diag(var(Xnew)))
           }
         }
       }
@@ -1157,7 +1164,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
   
   for (nc in min_nc:max_nc) {
     if (any(method == 1) || (method == 2) || (method == 3) || (method == 4) || 
-        (method == 5) || (method == 6) || (method == 7) || (method == 9)) {
+      (method == 5) || (method == 6) || (method == 7) || (method == 9)) {
       cl1 <- cutree(hc, k = nc)
       cl2 <- cutree(hc, k = nc + 1)
       clall <- cbind(cl1, cl2)
@@ -1196,8 +1203,8 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
       }
     }
     j <- table(cl1)  # table uses the cross-classifying factors to build a
-    # contingency table of the counts at each combination of
-    # factor levels.
+                    # contingency table of the counts at each combination of
+                    # factor levels.
     s <- sum(j == 1)
     j2 <- table(cl2)
     s2 <- sum(j2 == 1)
@@ -1208,37 +1215,37 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     ########### Cubic Clustering Criterion-CCC - 4e colonne de res ############
     if (any((indice == 4) || (indice == 31) || (indice == 32))) {
       res[nc - min_nc + 1, 4] <- Indices.WBT(x = jeu, cl = cl1, P = TT, s = ss,
-                                             vv = vv)[["ccc"]]
+        vv = vv)[["ccc"]]
     }
     ########### Scott and Symons - 5e colonne de res ############
     if (any((indice == 5) || (indice == 31) || (indice == 32))) {
       res[nc - min_nc + 1, 5] <- Indices.WBT(x = jeu, cl = cl1, P = TT, s = ss,
-                                             vv = vv)[["scott"]]
+        vv = vv)[["scott"]]
     }
     ########### Marriot - 6e colonne de res ############
     if (any((indice == 6) || (indice == 31) || (indice == 32))) {
       res[nc - min_nc + 1, 6] <- Indices.WBT(x = jeu, cl = cl1, P = TT, s = ss,
-                                             vv = vv)[["marriot"]]
+        vv = vv)[["marriot"]]
     }
     ########### Trace Cov W - 7e colonne de res ############
     if (any((indice == 7) || (indice == 31) || (indice == 32))) {
       res[nc - min_nc + 1, 7] <- Indices.WBT(x = jeu, cl = cl1, P = TT, s = ss,
-                                             vv = vv)[["trcovw"]]
+        vv = vv)[["trcovw"]]
     }
     ########### Trace W - 8e colonne de res ############
     if (any((indice == 8) || (indice == 31) || (indice == 32))) {
       res[nc - min_nc + 1, 8] <- Indices.WBT(x = jeu, cl = cl1, P = TT, s = ss,
-                                             vv = vv)[["tracew"]]
+        vv = vv)[["tracew"]]
     }
     ########### Friedman - 9e colonne de res ############
     if (any((indice == 9) || (indice == 31) || (indice == 32))) {
       res[nc - min_nc + 1, 9] <- Indices.WBT(x = jeu, cl = cl1, P = TT, s = ss,
-                                             vv = vv)[["friedman"]]
+        vv = vv)[["friedman"]]
     }
     ########### Rubin - 10e colonne de res ############
     if (any((indice == 10) || (indice == 31) || (indice == 32))) {
       res[nc - min_nc + 1, 10] <- Indices.WBT(x = jeu, cl = cl1, P = TT, s = ss,
-                                              vv = vv)[["rubin"]]
+        vv = vv)[["rubin"]]
     }
     ########### Indices.WKWL-duda - 14e colonne de res ############
     if (any((indice == 14) || (indice == 31) || (indice == 32))) {
@@ -1251,13 +1258,13 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
                                                cl2 = cl2)[["pseudot2"]]
     }
     ########### Indices.WKWL-beale - 16e colonne de res ############
-    if (any((indice == 16))) {
+    if (any((indice == 16) || (indice == 31) || (indice == 32))) {
       res[nc - min_nc + 1, 16] <- beale <- Indices.WKWL(x = jeu, cl1 = cl1, 
-                                                        cl2 = cl2)[["beale"]]
+        cl2 = cl2)[["beale"]]
     }
     ########### Indices.WKWL- duda or pseudot2 or beale ############
-    if (any((indice == 14) || (indice == 15) || (indice == 16) ||
-            (indice == 31) || (indice == 32))) {
+    if (any((indice == 14) || (indice == 15) || (indice == 16) || (indice == 
+      31) || (indice == 32))) {
       NM <- Indices.WKWL(x = jeu, cl1 = cl1, cl2 = cl2)[["NM"]]
       NK <- Indices.WKWL(x = jeu, cl1 = cl1, cl2 = cl2)[["NK"]]
       NL <- Indices.WKWL(x = jeu, cl1 = cl1, cl2 = cl2)[["NL"]]
@@ -1272,7 +1279,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
         resCritical[nc - min_nc + 1, 2] <- ((1 - critValue) / critValue) * 
           (NK + NL - 2)
       }
-      if (any((indice == 16))) {
+      if (any((indice == 16) || (indice == 31) || (indice == 32))) {
         df2 <- (NM - 2) * pp
         resCritical[nc - min_nc + 1, 3] <- 1 - pf(beale, pp, df2)
       }
@@ -1361,8 +1368,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
       ########### Indice.DB - 12e colonne de res ############
       if (any((indice == 12) || (indice == 31) || (indice == 32))) {
         res[nc - min_nc + 1, 12] <- Indice.DB(x = jeu, cl = cl1, d = NULL, 
-                                              centrotypes = "centroids", p = 2,
-                                              q = 2)[["DB"]]
+          centrotypes = "centroids", p = 2, q = 2)[["DB"]]
       }
       ########### Silhouette - 13e colonne de res ############
       if (any((indice == 13) || (indice == 31) || (indice == 32))) {
@@ -1495,7 +1501,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     foundDuda <- FALSE
     for (ncD in min_nc:max_nc) {
       if ((res[ncD - min_nc + 1, 14] >= resCritical[ncD - min_nc + 1, 1]) && 
-          (!foundDuda)) {
+        (!foundDuda)) {
         ncDuda <- ncD
         indiceDuda <- res[ncD - min_nc + 1, 14]
         foundDuda <- TRUE
@@ -1515,7 +1521,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     foundPseudo <- FALSE
     for (ncP in min_nc:max_nc) {
       if ((res[ncP - min_nc + 1, 15] <= resCritical[ncP - min_nc + 1, 2]) && 
-          (!foundPseudo)) {
+        (!foundPseudo)) {
         ncPseudo <- ncP
         indicePseudo <- res[ncP - min_nc + 1, 15]
         foundPseudo <- TRUE
@@ -1531,7 +1537,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     }
   }
   nc.Beale <- indice.Beale <- 0
-  if (any(indice == 16)) {
+  if (any((indice == 16) || (indice == 31) || (indice == 32))) {
     foundBeale <- FALSE
     for (ncB in min_nc:max_nc) {
       if ((resCritical[ncB - min_nc + 1, 3] >= alphaBeale) && (!foundBeale)) {
@@ -1623,60 +1629,57 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
         DiffLev[nc3 - min_nc + 1, 8] <- abs(res[nc3 - min_nc + 1, 10] - NA)
         DiffLev[nc3 - min_nc + 1, 9] <- abs(res[nc3 - min_nc + 1, 18] - NA)
         DiffLev[nc3 - min_nc + 1, 10] <- abs(res[nc3 - min_nc + 1, 27] - 
-                                               NA)
+          NA)
         DiffLev[nc3 - min_nc + 1, 12] <- abs(res[nc3 - min_nc + 1, 29] - 
-                                               NA)
+          NA)
       } else {
         if (nc3 == max_nc) {
           DiffLev[nc3 - min_nc + 1, 2] <- abs(res[nc3 - min_nc + 1, 3] - 
-                                                res[nc3 - min_nc, 3])
+          res[nc3 - min_nc, 3])
           DiffLev[nc3 - min_nc + 1, 3] <- abs(res[nc3 - min_nc + 1, 5] - 
-                                                res[nc3 - min_nc, 5])
+          res[nc3 - min_nc, 5])
           DiffLev[nc3 - min_nc + 1, 4] <- abs(res[nc3 - min_nc + 1, 6] - 
-                                                NA)
+          NA)
           DiffLev[nc3 - min_nc + 1, 5] <- abs(res[nc3 - min_nc + 1, 7] - 
-                                                res[nc3 - min_nc, 7])
+          res[nc3 - min_nc, 7])
           DiffLev[nc3 - min_nc + 1, 6] <- abs(res[nc3 - min_nc + 1, 8] - 
-                                                NA)   
+          NA)   
           DiffLev[nc3 - min_nc + 1, 7] <- abs(res[nc3 - min_nc + 1, 9] - 
-                                                res[nc3 - min_nc, 9])
+          res[nc3 - min_nc, 9])
           DiffLev[nc3 - min_nc + 1, 8] <- abs(res[nc3 - min_nc + 1, 10] - 
-                                                NA)
+          NA)
           DiffLev[nc3 - min_nc + 1, 9] <- abs(res[nc3 - min_nc + 1, 18] - 
-                                                res[nc3 - min_nc, 18])
+          res[nc3 - min_nc, 18])
           DiffLev[nc3 - min_nc + 1, 10] <- abs(res[nc3 - min_nc + 1, 27] - 
-                                                 NA)
+          NA)
           DiffLev[nc3 - min_nc + 1, 12] <- abs(res[nc3 - min_nc + 1, 29] - 
-                                                 NA)
+          NA)
         } else {
           DiffLev[nc3 - min_nc + 1, 2] <- abs(res[nc3 - min_nc + 1, 3] - 
-                                                res[nc3 - min_nc, 3])
+          res[nc3 - min_nc, 3])
           DiffLev[nc3 - min_nc + 1, 3] <- abs(res[nc3 - min_nc + 1, 5] - 
-                                                res[nc3 - min_nc, 5])
-          DiffLev[nc3 - min_nc + 1, 4] <- ((res[nc3 - min_nc + 2, 6] -
-                                              res[nc3 - min_nc + 1, 6]) -
-                                             (res[nc3 - min_nc + 1, 6] -
-                                                res[nc3 - min_nc, 6]))
+          res[nc3 - min_nc, 5])
+          DiffLev[nc3 - min_nc + 1, 4] <- ((res[nc3 - min_nc + 2, 6] - res[nc3 - 
+          min_nc + 1, 6]) - (res[nc3 - min_nc + 1, 6] - res[nc3 - min_nc, 
+          6]))
           DiffLev[nc3 - min_nc + 1, 5] <- abs(res[nc3 - min_nc + 1, 7] - 
-                                                res[nc3 - min_nc, 7])
-          DiffLev[nc3 - min_nc + 1, 6] <- ((res[nc3 - min_nc + 2, 8] -
-                                              res[nc3 - min_nc + 1, 8]) -
-                                             (res[nc3 - min_nc + 1, 8] -
-                                                res[nc3 - min_nc, 8]))
+          res[nc3 - min_nc, 7])
+          DiffLev[nc3 - min_nc + 1, 6] <- ((res[nc3 - min_nc + 2, 8] - res[nc3 - 
+          min_nc + 1, 8]) - (res[nc3 - min_nc + 1, 8] - res[nc3 - min_nc, 
+          8]))
           DiffLev[nc3 - min_nc + 1, 7] <- abs(res[nc3 - min_nc + 1, 9] - 
-                                                res[nc3 - min_nc, 9])
+          res[nc3 - min_nc, 9])
           DiffLev[nc3 - min_nc + 1, 8] <- ((res[nc3 - min_nc + 2, 10] -
                                               res[nc3 - min_nc + 1, 10]) -
                                              (res[nc3 - min_nc + 1, 10] -
                                                 res[nc3 - min_nc, 10]))
           DiffLev[nc3 - min_nc + 1, 9] <- abs(res[nc3 - min_nc + 1, 18] - 
-                                                res[nc3 - min_nc, 18])
+          res[nc3 - min_nc, 18])
           DiffLev[nc3 - min_nc + 1, 10] <- abs((res[nc3 - min_nc + 1, 27] - 
-                                                  res[nc3 - min_nc, 27]))
+          res[nc3 - min_nc, 27]))
           DiffLev[nc3 - min_nc + 1, 12] <- ((res[nc3 - min_nc + 2, 29] - 
-                                               res[nc3 - min_nc + 1, 29]) -
-                                              (res[nc3 - min_nc + 1, 29] -
-                                                 res[nc3 - min_nc, 29]))
+          res[nc3 - min_nc + 1, 29]) - (res[nc3 - min_nc + 1, 29] - res[nc3 - 
+          min_nc, 29]))
         }
       }
     }
@@ -1891,32 +1894,32 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
   
   if (any((indice == 31) || (indice == 32))) {
     message("*****************************************************************",
-            "\n")
+      "\n")
     message("* Among all indices:                                             ",
-            "\n")
+      "\n")
     BestCluster <- results1[1, ]
     c <- 0
     for (i in min.nc:max.nc) {
       vect <- which(BestCluster == i)
       if (length(vect) > 0) 
-        message("*", length(vect), " proposed ", i,
-                " as the best number of clusters", "\n")
+        message("*", length(vect), "proposed", i,
+                "as the best number of clusters", "\n")
       if (c < length(vect)) {
         j <- i
         c <- length(vect)
       }
     }
     message("\n", "               *****Conclusion*****                       ", 
-            "\n", "\n")
+      "\n", "\n")
     message("* According to the majority rule, the best number of clusters is ",
-            j, "\n", "\n", "\n")
+      j, "\n", "\n", "\n")
     message("*****************************************************************",
-            "\n")
+      "\n")
     
     ########################## The Best partition ###################
     
     if (any((method == 1) || (method == 2) || (method == 3) || (method == 4) ||
-            (method == 5) || (method == 6) || (method == 7) || (method == 9))) 
+      (method == 5) || (method == 6) || (method == 7) || (method == 9))) 
       partition <- cutree(hc, k = j)
     else {
       set.seed(1)
@@ -1933,7 +1936,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
           (indice == 25) || (indice == 26) || (indice == 28) ||
           (indice == 30))) {
     if (any((method == 1) || (method == 2) || (method == 3) || (method == 4) ||
-            (method == 5) || (method == 6) || (method == 7) || (method == 9))) 
+      (method == 5) || (method == 6) || (method == 7) || (method == 9))) 
       partition <- cutree(hc, k = best.nc)
     else {
       set.seed(1)
@@ -1946,7 +1949,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
   if (any((indice == 14) || (indice == 15) || (indice == 16) ||
           (indice == 20) || (indice == 31) || (indice == 32))) {
     results.final <- list(All.index = res, All.CriticalValues = resCritical, 
-                          Best.nc = resultats, Best.partition = partition)
+      Best.nc = resultats, Best.partition = partition)
   }
   if (any((indice == 27) || (indice == 29))) 
     results.final <- list(All.index = res)
@@ -1960,4 +1963,4 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     results.final <- list(All.index = res, Best.nc = resultats,
                           Best.partition = partition)
   return(results.final)
-}
+} 

--- a/R/NbClust.R
+++ b/R/NbClust.R
@@ -10,7 +10,7 @@
 #' NbClust Package for determining the best number of clusters
 #' @description An internal function using the \code{\link[NbClust]{NbClust}}
 #'   package. It provides 30 indices for determining the number of clusters and
-#'   proposes to user the best clustering scheme from the different results
+#'   proposes to the user the best clustering scheme from the different results
 #'   obtained by varying all combinations of number of clusters, distance
 #'   measures, and clustering methods.
 #' @param data matrix or dataset.
@@ -113,8 +113,17 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
       (indice == 32))) {
       for (i in 1:sizeEigenTT) {
         if (eigenValues[i] < 0) {
-          stop("The TSS matrix is indefinite. There must be too many missing ", 
-          "values. The index cannot be calculated.", call. = FALSE)
+          # Start here
+          # tcr_binary[is.na(tcr_binary)] <- 0
+          # NbClust(tcr_binary, distance = "binary", max.nc = 5, method = "average")
+          # Error: The TSS matrix is indefinite.
+          # Error: Division by zero!
+          # Figure out how many can be retained
+          message("The TSS matrix is indefinite. There must be too many ", 
+          "missing values. The following indices cannot be calculated:\n", 
+          "CCC, Scott, Marriot, TrCovW, TraceW, Friedman, and Rubin")
+          indef <- TRUE
+          break
         }
       }
       s1 <- sqrt(eigenValues)
@@ -633,7 +642,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     if (det(W) != 0) 
       scott <- n * log(det(P) / det(W)) 
     else {
-      message("Error: division by zero!")
+      scott <- NA
     }
     friedman <- tryCatch({
       sum(diag(solve(W) * B))

--- a/R/NbClust.R
+++ b/R/NbClust.R
@@ -71,7 +71,7 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
       (indice == 18) || (indice == 27) || (indice == 29) || (indice == 31) ||
       (indice == 32)) {
     if ((max.nc - min.nc) < 2) 
-      stop("The difference between the minimum and the maximum number of", 
+      stop("The difference between the minimum and the maximum number of ",
         "clusters must be at least equal to 2", call. = FALSE)
   }
   

--- a/R/NbClust.R
+++ b/R/NbClust.R
@@ -1484,11 +1484,17 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
   if (any((indice == 20) || (indice == 32))) {
     found <- FALSE
     for (ncG in min_nc:max_nc) {
-      if ((resCritical[ncG - min_nc + 1, 4] >= 0) && (!found)) {
-        ncGap <- ncG
-        indiceGap <- res[ncG - min_nc + 1, 20]
-        found <- TRUE
+      tryCatch({
+        if ((resCritical[ncG - min_nc + 1, 4] >= 0) && (!found)) {
+          ncGap <- ncG
+          indiceGap <- res[ncG - min_nc + 1, 20]
+          found <- TRUE
+        }
+      },
+      error = function(e) {
+        next
       }
+      )
     }
     if (found) {
       nc.Gap <- ncGap

--- a/R/NbClust.R
+++ b/R/NbClust.R
@@ -113,15 +113,9 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
       (indice == 32))) {
       for (i in 1:sizeEigenTT) {
         if (eigenValues[i] < 0) {
-          # Start here
-          # tcr_binary[is.na(tcr_binary)] <- 0
-          # NbClust(tcr_binary, distance = "binary", max.nc = 5, method = "average")
-          # Error: The TSS matrix is indefinite.
-          # Error: Division by zero!
-          # Figure out how many can be retained
           message("The TSS matrix is indefinite. There must be too many ", 
           "missing values. The following indices cannot be calculated:\n", 
-          "CCC, Scott, Marriot, TrCovW, TraceW, Friedman, and Rubin")
+          "CCC, Scott, Marriot, Friedman, and Ratkowsky")
           indef <- TRUE
           break
         }

--- a/R/NbClust.R
+++ b/R/NbClust.R
@@ -1890,8 +1890,8 @@ NbClust <- function(data = NULL, diss = NULL, distance = "euclidean",
     for (i in min.nc:max.nc) {
       vect <- which(BestCluster == i)
       if (length(vect) > 0) 
-        message("*", length(vect), "proposed", i,
-                "as the best number of clusters", "\n")
+        message("*", length(vect), " proposed ", i,
+                " as the best number of clusters", "\n")
       if (c < length(vect)) {
         j <- i
         c <- length(vect)

--- a/R/arg_validation.R
+++ b/R/arg_validation.R
@@ -124,13 +124,16 @@ validate_num_data <- function(d) {
                    call.=FALSE) 
             } else TRUE
           })
+  bool <- FALSE
   for (col in d) {
     uniq <- unique(col)
     if (all(uniq %in% 0:1)) {
       message("At least one column of 'd' contains only values 0 and 1.")
+      bool <- TRUE
       break
     }
   }
+  return(bool)
 }
 
 #' @title Validate that an argument contains positive integers

--- a/R/multi_clustering.R
+++ b/R/multi_clustering.R
@@ -124,7 +124,7 @@ multi_clust <- function(d, krange = 2:15, iter.max = 300, runs = 10,
                                         method = "average")))
   }, 
   error=function(e) {
-    if("computationally singular" %in% e) {
+    if(grepl("computationally singular", e)) {
       stop("There are not enough rows of data to evaluate for clustering.",
            call. = FALSE)
     } else {

--- a/R/multi_clustering.R
+++ b/R/multi_clustering.R
@@ -116,7 +116,26 @@ multi_clust <- function(d, krange = 2:15, iter.max = 300, runs = 10,
   km[["clust_gap"]] <- cluster::clusGap(d, kmeans, 
                                         K.max = length(km[["clust_model"]]), 
                                         B = 15, verbose = FALSE)
-  km[["k_best"]] <- which.max(km[["sil_avg"]])
+  tryCatch({
+    nb_best <- suppressWarnings(suppressMessages(NbClust(d,
+                                        min.nc = krange[1],
+                                        index = "all",
+                                        max.nc = krange[length(krange)],
+                                        method = "average")))
+  }, 
+  error=function(e) {
+    if("computationally singular" %in% e) {
+      stop("There are not enough rows of data to evaluate for clustering.",
+           call. = FALSE)
+    } else {
+      stop(e, call. = FALSE)
+    }
+  }
+  )
+  best <- aggregate(nb_best[["Best.nc"]][1, ], 
+                    by = list(nb_best[["Best.nc"]][1,]), length)
+  index <- which.max(best[[2]])
+  km[["k_best"]] <- best[index, 1]
   structure(km, class = "multiClust")
 }
 

--- a/R/multi_clustering.R
+++ b/R/multi_clustering.R
@@ -71,14 +71,19 @@
 #'     number of cluster centers requested.
 #'   \code{sil_avg} A list of average silhouette scores for each number of
 #'     cluster centers requested.
-#'   \code{num_clust} A list of the each number of clusters used.
+#'   \code{num_clust} A list of each number of clusters used.
 #'   \code{sil} A list of \code{\link[cluster]{silhouette}} objects for each
 #'     number of clusters.
 #'   \code{wss} A list of total within sum of squares for each of the
 #'     \code{\link[stats]{kmeans}} objects stored in \code{clust_model}.
 #'   \code{clust_gap} A \code{\link[cluster]{clusGap}} object that uses the
 #'     highest number of \code{krange} for the \code{K.max} argument.
-#'   \code{k_best} The optimal number of clusters based on silhouette score.
+#'   \code{k_best} The optimal number of clusters based on the algorithms used
+#'     by \code{\link[NbClust]{NbClust}}. These include: "kl", "ch",
+#'     "hartigan", "ccc", "scott", "marriot", "trcovw", "tracew", "friedman",
+#'     "rubin", "cindex", "db", "silhouette", "duda", "pseudot2", "beale",
+#'     "ratkowsky", "ball", "ptbiserial", "gap", "frey", "mcclain", "gamma",
+#'     "gplus", "tau", "dunn", "hubert", "sdindex", "dindex", "sdbw".
 #' 
 #' @export
 #'
@@ -119,7 +124,7 @@ multi_clust <- function(d, krange = 2:15, iter.max = 300, runs = 10,
   tryCatch({
     nb_best <- suppressWarnings(suppressMessages(NbClust(d,
                                         min.nc = krange[1],
-                                        index = "all",
+                                        index = "alllong",
                                         max.nc = krange[length(krange)],
                                         method = "average")))
   }, 
@@ -133,7 +138,7 @@ multi_clust <- function(d, krange = 2:15, iter.max = 300, runs = 10,
   }
   )
   best <- aggregate(nb_best[["Best.nc"]][1, ], 
-                    by = list(nb_best[["Best.nc"]][1,]), length)
+                    by = list(nb_best[["Best.nc"]][1, ]), length)
   index <- which.max(best[[2]])
   km[["k_best"]] <- best[index, 1]
   structure(km, class = "multiClust")

--- a/R/multi_clustering.R
+++ b/R/multi_clustering.R
@@ -122,43 +122,28 @@ multi_clust <- function(d, krange = 2:15, iter.max = 300, runs = 10,
                                         K.max = length(km[["clust_model"]]), 
                                         B = 15, verbose = FALSE)
   if (bool) {
-    tryCatch({
-      nb_best <- suppressWarnings(suppressMessages(
-        NbClust(d,
-                min.nc = krange[1],
-                index = "alllong",
-                max.nc = krange[length(krange)],
-                distance = "binary",
-                method = "average")))
-    },
-    error = function(e) {
-      if (grepl("computationally singular", e)) {
-        stop("There are not enough rows of data to evaluate for clustering.",
-             call. = FALSE)
-      } else {
-        stop(e, call. = FALSE)
-      }
-    }
-    )
+    distance <- "binary"
   } else {
-    tryCatch({
-      nb_best <- suppressWarnings(suppressMessages(
-        NbClust(d,
-                min.nc = krange[1],
-                index = "alllong",
-                max.nc = krange[length(krange)],
-                method = "average")))
-    },
-    error = function(e) {
-      if (grepl("computationally singular", e)) {
-        stop("There are not enough rows of data to evaluate for clustering.",
-             call. = FALSE)
-      } else {
-        stop(e, call. = FALSE)
-      }
-    }
-    )
+    distance <- "euclidean"
   }
+  tryCatch({
+    nb_best <- suppressWarnings(suppressMessages(
+      NbClust(d,
+              min.nc = krange[1],
+              index = "alllong",
+              max.nc = krange[length(krange)],
+              distance = distance,
+              method = "average")))
+  },
+  error = function(e) {
+    if (grepl("computationally singular", e)) {
+      stop("There are not enough rows of data to evaluate for clustering.",
+           call. = FALSE)
+    } else {
+      stop(e, call. = FALSE)
+    }
+  }
+  )
   best <- aggregate(nb_best[["Best.nc"]][1, ], 
                     by = list(nb_best[["Best.nc"]][1, ]), length)
   index <- which.max(best[[2]])

--- a/man/NbClust.Rd
+++ b/man/NbClust.Rd
@@ -46,7 +46,7 @@ Gamma, Gplus and Tau included).}
 \description{
 An internal function using the \code{\link[NbClust]{NbClust}}
   package. It provides 30 indices for determining the number of clusters and
-  proposes to user the best clustering scheme from the different results
+  proposes to the user the best clustering scheme from the different results
   obtained by varying all combinations of number of clusters, distance
   measures, and clustering methods.
 }

--- a/man/multi_clust.Rd
+++ b/man/multi_clust.Rd
@@ -34,14 +34,19 @@ does nothing, but functionality will be added in the future.}
     number of cluster centers requested.
   \code{sil_avg} A list of average silhouette scores for each number of
     cluster centers requested.
-  \code{num_clust} A list of the each number of clusters used.
+  \code{num_clust} A list of each number of clusters used.
   \code{sil} A list of \code{\link[cluster]{silhouette}} objects for each
     number of clusters.
   \code{wss} A list of total within sum of squares for each of the
     \code{\link[stats]{kmeans}} objects stored in \code{clust_model}.
   \code{clust_gap} A \code{\link[cluster]{clusGap}} object that uses the
     highest number of \code{krange} for the \code{K.max} argument.
-  \code{k_best} The optimal number of clusters based on silhouette score.
+  \code{k_best} The optimal number of clusters based on the algorithms used
+    by \code{\link[NbClust]{NbClust}}. These include: "kl", "ch",
+    "hartigan", "ccc", "scott", "marriot", "trcovw", "tracew", "friedman",
+    "rubin", "cindex", "db", "silhouette", "duda", "pseudot2", "beale",
+    "ratkowsky", "ball", "ptbiserial", "gap", "frey", "mcclain", "gamma",
+    "gplus", "tau", "dunn", "hubert", "sdindex", "dindex", "sdbw".
 }
 \description{
 This calls the function \code{\link[stats]{kmeans}} to perform kmeans 

--- a/tests/testthat/test_multi_clustering.R
+++ b/tests/testthat/test_multi_clustering.R
@@ -67,5 +67,13 @@ test_that("multiClust object can be generated with boolean data", {
 })
 
 test_that("multiClust object can be generated with non-boolean data", {
-  expect_that(multi_clust(fluidigm[1:40, ]), not(throws_error()))
+  expect_that(multi_clust(fluidigm[1:50, ]), not(throws_error()))
 })
+
+test_that("multiClust object finds correct k_best", {
+  k_best <- multi_clust(fluidigm[1:50, ], krange = 2:7)[["k_best"]]
+  expect_identical(k_best, 3)
+  k_best <- multi_clust(tcr_binary_data, krange = 2:7)[["k_best"]]
+  expect_identical(k_best, 2)
+})
+

--- a/tests/testthat/test_multi_clustering.R
+++ b/tests/testthat/test_multi_clustering.R
@@ -76,4 +76,3 @@ test_that("multiClust object finds correct k_best", {
   k_best <- multi_clust(tcr_binary_data, krange = 2:7)[["k_best"]]
   expect_identical(k_best, 2)
 })
-

--- a/tests/testthat/test_multi_clustering.R
+++ b/tests/testthat/test_multi_clustering.R
@@ -61,17 +61,16 @@ test_that("making sure multiClust object works properly", {
   expect_equal(length(f_clust[["k_best"]]), 1)
 })
 
-
 test_that("multiClust object can be generated with boolean data", {
   expect_that(multi_clust(tcr_binary_data), not(throws_error()))
 })
 
 test_that("multiClust object can be generated with non-boolean data", {
-  expect_that(multi_clust(fluidigm[1:50, ]), not(throws_error()))
+  expect_that(multi_clust(fluidigm[1:40, ]), not(throws_error()))
 })
 
 test_that("multiClust object finds correct k_best", {
-  k_best <- multi_clust(fluidigm[1:50, ], krange = 2:7)[["k_best"]]
+  k_best <- multi_clust(fluidigm[1:40, ], krange = 2:7)[["k_best"]]
   expect_identical(k_best, 3)
   k_best <- multi_clust(tcr_binary_data, krange = 2:7)[["k_best"]]
   expect_identical(k_best, 2)

--- a/tests/testthat/test_nbclust.R
+++ b/tests/testthat/test_nbclust.R
@@ -3,6 +3,7 @@ context("Unit test NbClust")
 # data prep
 data(fluidigm)
 f50 <- fluidigm[1:50, ]
+data(iris)
 # Load pre-computed multiClust object from fluidigm data set. This same object
 # should be used in 'test_cluster_plotting.R' test cases. It was generated
 # using 'data(fluidigm); f_clust <- fluidigm[1:50, ].
@@ -67,4 +68,14 @@ test_that("making sure NbClust object picks right number of clusters", {
   index <- which.max(best[[2]])
   k_best <- best[index, 1]
   expect_identical(k_best, 2)
+  nb_best <- suppressWarnings(NbClust(iris[1:4],
+                                      min.nc = 3,
+                                      index = "alllong",
+                                      max.nc = 7,
+                                      method = "average"))
+  best <- aggregate(nb_best[["Best.nc"]][1, ], 
+                    by = list(nb_best[["Best.nc"]][1, ]), length)
+  index <- which.max(best[[2]])
+  k_best <- best[index, 1]
+  expect_identical(k_best, 3)
 })

--- a/tests/testthat/test_nbclust.R
+++ b/tests/testthat/test_nbclust.R
@@ -47,3 +47,17 @@ test_that("making sure NbClust object can be generated with non-boolean data", {
   expect_that(suppressWarnings(NbClust(f50, max.nc = 5, method = "average")),
               not(throws_error()))
 })
+
+test_that("making sure NbClust object picks right number of clusters", {
+  nb_best <- suppressWarnings(NbClust(f50,
+                                      min.nc = 2,
+                                      index = "alllong",
+                                      max.nc = 7,
+                                      method = "average"))
+  best <- aggregate(nb_best[["Best.nc"]][1, ], 
+                    by = list(nb_best[["Best.nc"]][1, ]), length)
+  index <- which.max(best[[2]])
+  k_best <- best[index, 1]
+  expect_identical(k_best, 3)
+})
+

--- a/tests/testthat/test_nbclust.R
+++ b/tests/testthat/test_nbclust.R
@@ -13,18 +13,19 @@ tcr_binary_data[is.na(tcr_binary_data)] <- 0
 # Load TCR data set with only data points and all data points as 0 or 1.
 #load(system.file("extdata", "tcr_binary_data.rda", package="receptormarker"))
 
-test_that("making sure argument is acceptable range works properly", {
+#test_that("making sure argument is acceptable range works properly", {
   
-})
+#})
 
-test_that("multiClust object can be generated with boolean data", {
-  expect_that(NbClust(tcr_binary_data,
-                      distance = "binary",
-                      max.nc = 5,
-                      method = "average"),
+test_that("NbClust object can be generated with boolean data", {
+  expect_that(suppressWarnings(NbClust(tcr_binary_data,
+                               distance = "binary",
+                               max.nc = 5,
+                               method = "average")),
               not(throws_error()))
 })
 
-test_that("multiClust object can be generated with non-boolean data", {
-  expect_that(multi_clust(fluidigm[1:40, ]), not(throws_error()))
+test_that("NbClust object can be generated with non-boolean data", {
+  expect_that(suppressWarnings(NbClust(f50, max.nc = 5, method = "average")),
+              not(throws_error()))
 })

--- a/tests/testthat/test_nbclust.R
+++ b/tests/testthat/test_nbclust.R
@@ -4,6 +4,17 @@ context("Unit test NbClust")
 data(fluidigm)
 f40 <- fluidigm[1:40, ]
 data(iris)
+rep_row <- function(d, n) {
+  new_d <- c()
+  for (i in 1:n) {
+    new_d <- rbind(new_d, d)
+  }
+  return(new_d)
+}
+clust_data <- rbind(rep_row(c(1, rep(0, 8)), 20),
+                    rep_row(c(rep(0, 8), 1), 15),
+                    rep_row(c(rep(0, 4), 1, rep(0, 4)), 55))
+rownames(clust_data) <- 1:90
 # Load pre-computed multiClust object from fluidigm data set. This same object
 # should be used in 'test_cluster_plotting.R' test cases. It was generated
 # using 'data(fluidigm); f_clust <- fluidigm[1:50, ].
@@ -72,6 +83,17 @@ test_that("making sure NbClust object picks right number of clusters", {
                                       min.nc = 3,
                                       index = "alllong",
                                       max.nc = 7,
+                                      method = "average"))
+  best <- aggregate(nb_best[["Best.nc"]][1, ], 
+                    by = list(nb_best[["Best.nc"]][1, ]), length)
+  index <- which.max(best[[2]])
+  k_best <- best[index, 1]
+  expect_identical(k_best, 3)
+  nb_best <- suppressWarnings(NbClust(clust_data,
+                                      min.nc = 2,
+                                      index = "alllong",
+                                      max.nc = 7,
+                                      distance = "binary",
                                       method = "average"))
   best <- aggregate(nb_best[["Best.nc"]][1, ], 
                     by = list(nb_best[["Best.nc"]][1, ]), length)

--- a/tests/testthat/test_nbclust.R
+++ b/tests/testthat/test_nbclust.R
@@ -13,11 +13,29 @@ tcr_binary_data[is.na(tcr_binary_data)] <- 0
 # Load TCR data set with only data points and all data points as 0 or 1.
 #load(system.file("extdata", "tcr_binary_data.rda", package="receptormarker"))
 
-#test_that("making sure argument is acceptable range works properly", {
-  
-#})
+test_that("making sure invalid arguments produce errors", {
+  expect_error(suppressWarnings(NbClust(f50, max.nc = 5, method = 9)),
+               "clustering method")
+  expect_error(suppressWarnings(NbClust(max.nc = 5, method = "average")),
+               "Data matrix")
+  expect_error(suppressWarnings(NbClust(f50, max.nc = 5, method = "average",
+                                        distance = 9)),
+               "distance")
+  expect_error(suppressWarnings(NbClust(f50, max.nc = 5, method = "average",
+                                        index = 9)),
+               "clustering index")
+  expect_error(suppressWarnings(NbClust(f50, method = "average",
+                                        min.nc = "no")),
+               "non-numeric")
+  expect_error(suppressWarnings(NbClust(f50, method = "average",
+                                        max.nc = "no")),
+               "non-numeric")
+  expect_error(suppressWarnings(NbClust(f50, max.nc = 5, method = "average",
+                                        min.nc = 7)),
+               "difference between the minimum")
+})
 
-test_that("NbClust object can be generated with boolean data", {
+test_that("making sure NbClust object can be generated with boolean data", {
   expect_that(suppressWarnings(NbClust(tcr_binary_data,
                                distance = "binary",
                                max.nc = 5,
@@ -25,7 +43,7 @@ test_that("NbClust object can be generated with boolean data", {
               not(throws_error()))
 })
 
-test_that("NbClust object can be generated with non-boolean data", {
+test_that("making sure NbClust object can be generated with non-boolean data", {
   expect_that(suppressWarnings(NbClust(f50, max.nc = 5, method = "average")),
               not(throws_error()))
 })

--- a/tests/testthat/test_nbclust.R
+++ b/tests/testthat/test_nbclust.R
@@ -6,7 +6,7 @@ f50 <- fluidigm[1:50, ]
 # Load pre-computed multiClust object from fluidigm data set. This same object
 # should be used in 'test_cluster_plotting.R' test cases. It was generated
 # using 'data(fluidigm); f_clust <- fluidigm[1:50, ].
-use load(system.file("extdata", "f_clust.rda", package="receptormarker"))
+load(system.file("extdata", "f_clust.rda", package="receptormarker"))
 # Load TCR data set with only data points and all data points as 0 or 1.
 load(system.file("extdata", "tcr_binary_data.rda", package="receptormarker"))
 

--- a/tests/testthat/test_nbclust.R
+++ b/tests/testthat/test_nbclust.R
@@ -1,0 +1,22 @@
+context("Unit test NbClust")
+
+data(fluidigm)
+f50 <- fluidigm[1:50, ]
+# Load pre-computed multiClust object from fluidigm data set. This same object
+# should be used in 'test_cluster_plotting.R' test cases. It was generated
+# using 'data(fluidigm); f_clust <- fluidigm[1:50, ].
+#load(system.file("extdata", "f_clust.rda", package="receptormarker"))
+# Load TCR data set with only data points and all data points as 0 or 1.
+#load(system.file("extdata", "tcr_binary_data.rda", package="receptormarker"))
+
+test_that("making sure argument is acceptable range works properly", {
+  
+})
+
+test_that("multiClust object can be generated with boolean data", {
+  expect_that(NbClust(tcr_binary_data), not(throws_error()))
+})
+
+test_that("multiClust object can be generated with non-boolean data", {
+  expect_that(multi_clust(fluidigm[1:40, ]), not(throws_error()))
+})

--- a/tests/testthat/test_nbclust.R
+++ b/tests/testthat/test_nbclust.R
@@ -1,7 +1,11 @@
 context("Unit test NbClust")
 
+# data prep
 data(fluidigm)
 f50 <- fluidigm[1:50, ]
+data(tcr)
+tcr_binary_data <- tcr[3:23]
+tcr_binary_data[is.na(tcr_binary_data)] <- 0
 # Load pre-computed multiClust object from fluidigm data set. This same object
 # should be used in 'test_cluster_plotting.R' test cases. It was generated
 # using 'data(fluidigm); f_clust <- fluidigm[1:50, ].
@@ -14,7 +18,11 @@ test_that("making sure argument is acceptable range works properly", {
 })
 
 test_that("multiClust object can be generated with boolean data", {
-  expect_that(NbClust(tcr_binary_data), not(throws_error()))
+  expect_that(NbClust(tcr_binary_data,
+                      distance = "binary",
+                      max.nc = 5,
+                      method = "average"),
+              not(throws_error()))
 })
 
 test_that("multiClust object can be generated with non-boolean data", {

--- a/tests/testthat/test_nbclust.R
+++ b/tests/testthat/test_nbclust.R
@@ -59,5 +59,16 @@ test_that("making sure NbClust object picks right number of clusters", {
   index <- which.max(best[[2]])
   k_best <- best[index, 1]
   expect_identical(k_best, 3)
+  nb_best <- suppressWarnings(NbClust(tcr_binary_data,
+                                      min.nc = 2,
+                                      index = "alllong",
+                                      max.nc = 7,
+                                      distance = "binary",
+                                      method = "average"))
+  best <- aggregate(nb_best[["Best.nc"]][1, ], 
+                    by = list(nb_best[["Best.nc"]][1, ]), length)
+  index <- which.max(best[[2]])
+  k_best <- best[index, 1]
+  expect_identical(k_best, 2)
 })
 

--- a/tests/testthat/test_nbclust.R
+++ b/tests/testthat/test_nbclust.R
@@ -3,15 +3,12 @@ context("Unit test NbClust")
 # data prep
 data(fluidigm)
 f50 <- fluidigm[1:50, ]
-data(tcr)
-tcr_binary_data <- tcr[3:23]
-tcr_binary_data[is.na(tcr_binary_data)] <- 0
 # Load pre-computed multiClust object from fluidigm data set. This same object
 # should be used in 'test_cluster_plotting.R' test cases. It was generated
 # using 'data(fluidigm); f_clust <- fluidigm[1:50, ].
-#load(system.file("extdata", "f_clust.rda", package="receptormarker"))
+use load(system.file("extdata", "f_clust.rda", package="receptormarker"))
 # Load TCR data set with only data points and all data points as 0 or 1.
-#load(system.file("extdata", "tcr_binary_data.rda", package="receptormarker"))
+load(system.file("extdata", "tcr_binary_data.rda", package="receptormarker"))
 
 test_that("making sure invalid arguments produce errors", {
   expect_error(suppressWarnings(NbClust(f50, max.nc = 5, method = 9)),
@@ -71,4 +68,3 @@ test_that("making sure NbClust object picks right number of clusters", {
   k_best <- best[index, 1]
   expect_identical(k_best, 2)
 })
-

--- a/tests/testthat/test_nbclust.R
+++ b/tests/testthat/test_nbclust.R
@@ -2,7 +2,7 @@ context("Unit test NbClust")
 
 # data prep
 data(fluidigm)
-f50 <- fluidigm[1:50, ]
+f40 <- fluidigm[1:40, ]
 data(iris)
 # Load pre-computed multiClust object from fluidigm data set. This same object
 # should be used in 'test_cluster_plotting.R' test cases. It was generated
@@ -12,23 +12,23 @@ load(system.file("extdata", "f_clust.rda", package="receptormarker"))
 load(system.file("extdata", "tcr_binary_data.rda", package="receptormarker"))
 
 test_that("making sure invalid arguments produce errors", {
-  expect_error(suppressWarnings(NbClust(f50, max.nc = 5, method = 9)),
+  expect_error(suppressWarnings(NbClust(f40, max.nc = 5, method = 9)),
                "clustering method")
   expect_error(suppressWarnings(NbClust(max.nc = 5, method = "average")),
                "Data matrix")
-  expect_error(suppressWarnings(NbClust(f50, max.nc = 5, method = "average",
+  expect_error(suppressWarnings(NbClust(f40, max.nc = 5, method = "average",
                                         distance = 9)),
                "distance")
-  expect_error(suppressWarnings(NbClust(f50, max.nc = 5, method = "average",
+  expect_error(suppressWarnings(NbClust(f40, max.nc = 5, method = "average",
                                         index = 9)),
                "clustering index")
-  expect_error(suppressWarnings(NbClust(f50, method = "average",
+  expect_error(suppressWarnings(NbClust(f40, method = "average",
                                         min.nc = "no")),
                "non-numeric")
-  expect_error(suppressWarnings(NbClust(f50, method = "average",
+  expect_error(suppressWarnings(NbClust(f40, method = "average",
                                         max.nc = "no")),
                "non-numeric")
-  expect_error(suppressWarnings(NbClust(f50, max.nc = 5, method = "average",
+  expect_error(suppressWarnings(NbClust(f40, max.nc = 5, method = "average",
                                         min.nc = 7)),
                "difference between the minimum")
 })
@@ -42,12 +42,12 @@ test_that("making sure NbClust object can be generated with boolean data", {
 })
 
 test_that("making sure NbClust object can be generated with non-boolean data", {
-  expect_that(suppressWarnings(NbClust(f50, max.nc = 5, method = "average")),
+  expect_that(suppressWarnings(NbClust(f40, max.nc = 5, method = "average")),
               not(throws_error()))
 })
 
 test_that("making sure NbClust object picks right number of clusters", {
-  nb_best <- suppressWarnings(NbClust(f50,
+  nb_best <- suppressWarnings(NbClust(f40,
                                       min.nc = 2,
                                       index = "alllong",
                                       max.nc = 7,


### PR DESCRIPTION
This pull request adds a new method for determining the best number of clusters in `multi_clust` to use for a given data set. Specifically,
- `validate_num_data` now returns a boolean variable indicating whether or not the data set fed into it is boolean or not. Previously, it simply sent a message to the screen when this was the case.  
- The `NbClust` function was brought in from the _NbClust_ package, based on the GNU public license, and adapted to be more robust in cases where not all algorithms can be used.  
- `multi_clust` calls the `NbClust` function to determine the ideal number of clusters for a data set, labeled `k_best` in the _multiClust_ object.  
- `multi_clust` leverages the new variable returned by `validate_num_data` to call `NbClust` differently if a binary data set is being used.  
