### PR TITLE
Fix clust_boxplot handling of boolean data

### DIFF
--- a/R/cluster_plotting.R
+++ b/R/cluster_plotting.R
@@ -389,13 +389,15 @@ clust_boxplot <- function(d, clust_obj, num_clust, ...) {
     d_bool <- aggregate(. ~ cluster, data = d, sum)
     d_bool[meas_vars] <- d_bool[meas_vars] / nrow(d)
     m <- reshape2::melt(d_bool, id.vars = "cluster", measure.vars = meas_vars)
-    ggplot2::qplot(x = as.factor(cluster), y = value, data = m, geom = "bar", 
-                   stat = "identity", fill = as.factor(cluster), xlab = NULL, 
-                   ylab = "Proportion expressed", ...) + 
-      ggplot2::facet_wrap(~variable, ncol=boxplot_num_cols(num_clust)) + 
+    ggplot2::ggplot(data = m, aes(x = as.factor(cluster), y = value,
+                                  fill = as.factor(cluster))) +
+      ggplot2::geom_bar(stat = "identity") +
+      ggplot2::ylab("Proportion expressed") +
+      ggplot2::facet_wrap(~variable, ncol = boxplot_num_cols(num_clust)) + 
       ggplot2::scale_fill_discrete(name = "Cluster") +
       ggplot2::theme(
-        axis.text=ggplot2::element_text(size=axis_label_size(num_clust))
+        axis.text=ggplot2::element_text(size=axis_label_size(num_clust)),
+        axis.title.x=element_blank()
       )
   } else {
     m <- reshape2::melt(d, id.vars = "cluster", measure.vars = meas_vars)

--- a/R/multi_clustering.R
+++ b/R/multi_clustering.R
@@ -103,33 +103,7 @@ multi_clust <- function(d, krange = 2:15, iter.max = 300, runs = 10,
   km[["clust_gap"]] <- cluster::clusGap(d, kmeans, 
                                         K.max = length(km[["clust_model"]]), 
                                         B = 15, verbose = FALSE)
-  if (bool) {
-    distance <- "binary"
-  } else {
-    distance <- "euclidean"
-  }
-  tryCatch({
-    nb_best <- suppressWarnings(suppressMessages(
-              NbClust(d,
-              min.nc = krange[1],
-              index = index,
-              max.nc = krange[length(krange)],
-              distance = distance,
-              method = "average")))
-  },
-  error = function(e) {
-    if (grepl("computationally singular", e)) {
-      stop("There are not enough rows of data to evaluate for clustering.",
-           call. = FALSE)
-    } else {
-      stop(e, call. = FALSE)
-    }
-  }
-  )
-  best <- aggregate(nb_best[["Best.nc"]][1, ], 
-                    by = list(nb_best[["Best.nc"]][1, ]), length)
-  idx <- which.max(best[[2]])
-  km[["k_best"]] <- best[idx, 1]
+  km[["k_best"]] <- which.max(km[["sil_avg"]])
   new("multiClust", clust_model=km[["clust_model"]], sil_avg=km[["sil_avg"]],
       num_clust=km[["num_clust"]], sil=km[["sil"]], clust_gap=km[["clust_gap"]],
       wss=km[["wss"]], k_best=km[["k_best"]])


### PR DESCRIPTION
This pull request reverts `multi_clust` to use average silhouette score instead of the `NbClust` function to determine the best number of clusters and modifies the `clust_boxplot` function to plot boolean data properly.
