### PR TITLE
Add pca facet wrap

### DIFF
--- a/R/arg_validation.R
+++ b/R/arg_validation.R
@@ -158,12 +158,12 @@ validate_pos_num <- function(n) {
 #' @param n An item to be checked.
 #' @keywords internal
 validate_single_pos_num <- function(n) {
-  if (is.na(n)) {
+  if (length(n) != 1) {
+    stop("Argument 'n' must be a single integer", call.=FALSE)
+  } else if (is.na(n)) {
     stop("Argument 'n' must be a real value", call.=FALSE)
   } else if (class(n) != "numeric") {
     stop("Argument 'n' must be an integer", call.=FALSE)
-  } else if (length(n) != 1) {
-    stop("Argument 'n' must be a single integer", call.=FALSE)
   } else if(n == 0) {
     stop("Argument 'n' must be greater than 0", call.=FALSE)
   } else if (grep("^[0-9]+$", n) != 1) {

--- a/R/cluster_plotting.R
+++ b/R/cluster_plotting.R
@@ -161,8 +161,19 @@ gap_plot <- function(clust_obj, optimal = FALSE, ...) {
 pca_plot <- function(d, clust_obj, num_clust, ...) {
   validate_num_data(d)
   validate_multi_clust(clust_obj)
-  # Use pos_num validation since num_clust could be vector or single int
-  validate_pos_num(list(num_clust = num_clust))
+  # Use pos_num and k_range validation since num_clust could be vector
+  # or single int
+  tryCatch({
+    validate_single_pos_num(num_clust)
+  },
+  error = function(e) {
+    if (grepl("integer", e)) {
+      validate_k_range(num_clust)
+    } else {
+      stop(e, call. = FALSE)
+    }
+  }
+  )
   pca <- stats::princomp(d)
   scores <- as.data.frame(pca[["scores"]][, 1:2])
   sdev <- pca[["sdev"]]

--- a/R/cluster_plotting.R
+++ b/R/cluster_plotting.R
@@ -170,7 +170,7 @@ pca_plot <- function(d, clust_obj, num_clust, ...) {
     if (grepl("integer", e)) {
       validate_k_range(num_clust)
     } else {
-      stop(e, call. = FALSE)
+      suppressWarnings(stop(e, call. = FALSE))
     }
   }
   )

--- a/R/cluster_plotting.R
+++ b/R/cluster_plotting.R
@@ -161,8 +161,8 @@ gap_plot <- function(clust_obj, optimal = FALSE, ...) {
 pca_plot <- function(d, clust_obj, num_clust, ...) {
   validate_num_data(d)
   validate_multi_clust(clust_obj)
-  # Use k_range validation since num_clust could be vector
-  validate_k_range(num_clust)
+  # Use pos_num validation since num_clust could be vector or single int
+  validate_pos_num(list(num_clust = num_clust))
   pca <- stats::princomp(d)
   scores <- as.data.frame(pca[["scores"]][, 1:2])
   sdev <- pca[["sdev"]]

--- a/R/cluster_plotting.R
+++ b/R/cluster_plotting.R
@@ -116,35 +116,39 @@ gap_plot <- function(clust_obj, optimal = FALSE, ...) {
 #' calculated using \code{\link[stats]{princomp}}. It represents each cluster
 #' with a different color so that one can understand the distribution of the
 #' clusters based on the first two components. It is a wrapper on the
-#' \code{\link[graphics]{plot}} function.
+#' \code{\link[ggplot2]{ggplot}} function.
 #' 
 #' @details This function is intended to be used to view the shape of a given
 #'   clustering to use for analysis. Principal component analysis looks for the
 #'   way to represent the data such that the most variance is explained using a
 #'   linear combination of the features. See \code{\link[stats]{princomp}} for
 #'   further details on its calculation. Here it is used strictly for its
-#'   ability to represent the data relatively well in just a couple dimensions.  
+#'   ability to represent the data relatively well in just a couple dimensions.
 #'   One may pass in the \code{k_best} element from the
-#'   \code{\link{multiClust-class}} object for \code{num_clust}, or use a
-#'   different value. This is where other visualizations can be useful.  
+#'   \code{\link{multiClust-class}} object for \code{num_clust}, or pass in a
+#'   vector of values. If a vector of values is passed in, then the plots will
+#'   be wrapped together and the data colored by each respective number of
+#'   clusters. This is where other visualizations can be useful.
 #'   See the \emph{Details} section for the \code{\link{multi_clust}} function
 #'   and view the \emph{TIP} for a suggested workflow.
 #'
 #' @param d A numeric matrix of data, or an object that can be coerced to
 #'   such a matrix (such as a numeric vector or a data frame with all numeric
-#'   columns). Note: This should be the same one used to generate 
+#'   columns). Note: This should be the same one used to generate
 #'   \code{clust_obj}.
 #' @param clust_obj A \code{\link{multiClust-class}} object from which to
-#' extract \code{clust_model} based on the argument \code{num_clust}
-#' @param num_clust An integer. The desired number of clusters to be used. Note:
-#'   This integer should fall within the krange used to generate the 
-#'   \code{\link{multiClust-class}} object.
-#' @param ... Further arguments to be passed to the \code{\link{plot}} 
-#'   function (besides \code{xlab}, \code{ylab}, \code{main}).
+#'   extract \code{clust_model} based on the argument \code{num_clust}
+#' @param num_clust An integer, or vector of integers. The desired number of
+#'   clusters to be used. Note: This integer, or vector of integers, should
+#'   fall within the krange used to generate the \code{\link{multiClust-class}}
+#'   object.
+#' @param ... Further arguments to be passed to the
+#'   \code{\link[ggplot2]{ggplot}} function (besides the labels and title of
+#'   the plot).
 #'
 #' @export
 #'
-#' @seealso \code{\link{multi_clust}}, \code{\link{wss_plot}}, 
+#' @seealso \code{\link{multi_clust}}, \code{\link{wss_plot}},
 #'   \code{\link{gap_plot}}, \code{\link{sil_plot}},
 #'   \code{\link{avg_sil_plot}}, \code{\link{clust_boxplot}}
 #'

--- a/R/multi_clustering.R
+++ b/R/multi_clustering.R
@@ -37,8 +37,9 @@
 #'   \item Choose the number of clusters to be used.
 #'   \item View the \code{\link{sil_plot}} using your chosen number of
 #'     clusters to confirm the choice.
-#'   \item View the \code{\link{pca_plot}} using your chosen number of clusters
-#'     to see the shape of the data using its first two principal components.
+#'   \item View the \code{\link{pca_plot}} using your chosen number or range
+#'     of clusters to see the shape of the data using its first two principal
+#'     components.
 #'   \item View the \code{\link{clust_boxplot}} using your chosen number of
 #'     clusters to see the cluster membership of each feature (likely
 #'     phenotypic markers). This should yield useful conclusions.

--- a/man/clust_boxplot.Rd
+++ b/man/clust_boxplot.Rd
@@ -25,7 +25,7 @@ function (besides \code{xlab}, \code{ylab}).}
 }
 \description{
 This function plots cluster membership for each feature of \code{d} using box
-plots. It utlizes \code{facet_wrap} in the \code{\link[ggplot2]{qplot}}
+plots. It utilizes \code{facet_wrap} in the \code{\link[ggplot2]{qplot}}
 function and the desired \code{clust_model} from the argument 
 \code{clust_obj} to show the box plots of each feature after using the
 \code{\link[reshape2]{melt}} function to get the correct form of \code{d}.

--- a/man/multi_clust.Rd
+++ b/man/multi_clust.Rd
@@ -84,8 +84,9 @@ down in number, few changes in performance should be observed here.
   \item Choose the number of clusters to be used.
   \item View the \code{\link{sil_plot}} using your chosen number of
     clusters to confirm the choice.
-  \item View the \code{\link{pca_plot}} using your chosen number of clusters
-    to see the shape of the data using its first two principal components.
+  \item View the \code{\link{pca_plot}} using your chosen number or range
+    of clusters to see the shape of the data using its first two principal
+    components.
   \item View the \code{\link{clust_boxplot}} using your chosen number of
     clusters to see the cluster membership of each feature (likely
     phenotypic markers). This should yield useful conclusions.

--- a/man/pca_plot.Rd
+++ b/man/pca_plot.Rd
@@ -9,18 +9,20 @@ pca_plot(d, clust_obj, num_clust, ...)
 \arguments{
 \item{d}{A numeric matrix of data, or an object that can be coerced to
 such a matrix (such as a numeric vector or a data frame with all numeric
-columns). Note: This should be the same one used to generate 
+columns). Note: This should be the same one used to generate
 \code{clust_obj}.}
 
 \item{clust_obj}{A \code{\link{multiClust-class}} object from which to
 extract \code{clust_model} based on the argument \code{num_clust}}
 
-\item{num_clust}{An integer. The desired number of clusters to be used. Note:
-This integer should fall within the krange used to generate the 
-\code{\link{multiClust-class}} object.}
+\item{num_clust}{An integer, or vector of integers. The desired number of
+clusters to be used. Note: This integer, or vector of integers, should
+fall within the krange used to generate the \code{\link{multiClust-class}}
+object.}
 
-\item{...}{Further arguments to be passed to the \code{\link{plot}} 
-function (besides \code{xlab}, \code{ylab}, \code{main}).}
+\item{...}{Further arguments to be passed to the
+\code{\link[ggplot2]{ggplot}} function (besides the labels and title of
+the plot).}
 }
 \description{
 This function plots the instances of \code{data} using the first two
@@ -28,7 +30,7 @@ principal components as the x and y axes, respectively. These components are
 calculated using \code{\link[stats]{princomp}}. It represents each cluster
 with a different color so that one can understand the distribution of the
 clusters based on the first two components. It is a wrapper on the
-\code{\link[graphics]{plot}} function.
+\code{\link[ggplot2]{ggplot}} function.
 }
 \details{
 This function is intended to be used to view the shape of a given
@@ -36,10 +38,12 @@ This function is intended to be used to view the shape of a given
   way to represent the data such that the most variance is explained using a
   linear combination of the features. See \code{\link[stats]{princomp}} for
   further details on its calculation. Here it is used strictly for its
-  ability to represent the data relatively well in just a couple dimensions.  
+  ability to represent the data relatively well in just a couple dimensions.
   One may pass in the \code{k_best} element from the
-  \code{\link{multiClust-class}} object for \code{num_clust}, or use a
-  different value. This is where other visualizations can be useful.  
+  \code{\link{multiClust-class}} object for \code{num_clust}, or pass in a
+  vector of values. If a vector of values is passed in, then the plots will
+  be wrapped together and the data colored by each respective number of
+  clusters. This is where other visualizations can be useful.
   See the \emph{Details} section for the \code{\link{multi_clust}} function
   and view the \emph{TIP} for a suggested workflow.
 }
@@ -51,7 +55,7 @@ iris_cluster <- multi_clust(iris[, 1:4])
 pca_plot(iris[, 1:4], iris_cluster, num_clust = 3)
 }
 \seealso{
-\code{\link{multi_clust}}, \code{\link{wss_plot}}, 
+\code{\link{multi_clust}}, \code{\link{wss_plot}},
   \code{\link{gap_plot}}, \code{\link{sil_plot}},
   \code{\link{avg_sil_plot}}, \code{\link{clust_boxplot}}
 }

--- a/tests/testthat/test_cluster_plotting.R
+++ b/tests/testthat/test_cluster_plotting.R
@@ -24,7 +24,7 @@ test_that("validation functions work properly in pca_plot", {
   expect_error(pca_plot(1, f_clust, num_clust=4), "data.frame or matrix")
   expect_error(pca_plot(fluidigm, 1, num_clust=4),
                "object of class 'multiClust'")
-  expect_error(pca_plot(fluidigm, f_clust, num_clust=-1), "num_clust")
+  expect_error(pca_plot(fluidigm, f_clust, num_clust=-1), "krange")
   expect_silent(pca_plot(fluidigm, f_clust, num_clust = 2:4))
 })
 

--- a/tests/testthat/test_cluster_plotting.R
+++ b/tests/testthat/test_cluster_plotting.R
@@ -24,7 +24,7 @@ test_that("validation functions work properly in pca_plot", {
   expect_error(pca_plot(1, f_clust, num_clust=4), "data.frame or matrix")
   expect_error(pca_plot(fluidigm, 1, num_clust=4),
                "object of class 'multiClust'")
-  expect_error(pca_plot(fluidigm, f_clust, num_clust=-1), "krange")
+  expect_error(pca_plot(fluidigm, f_clust, num_clust=-1), "length zero")
   expect_silent(pca_plot(fluidigm, f_clust, num_clust = 2:4))
 })
 

--- a/tests/testthat/test_cluster_plotting.R
+++ b/tests/testthat/test_cluster_plotting.R
@@ -24,8 +24,9 @@ test_that("validation functions work properly in pca_plot", {
   expect_error(pca_plot(1, f_clust, num_clust=4), "data.frame or matrix")
   expect_error(pca_plot(fluidigm, 1, num_clust=4),
                "object of class 'multiClust'")
-  expect_error(pca_plot(fluidigm, f_clust, num_clust=-1), "length zero")
-  expect_silent(pca_plot(fluidigm, f_clust, num_clust = 2:4))
+  expect_error(pca_plot(fluidigm[1:50, ], f_clust, num_clust=-1),
+               "length zero")
+  expect_silent(pca_plot(fluidigm[1:50, ], f_clust, num_clust = 2:4))
 })
 
 

--- a/tests/testthat/test_cluster_plotting.R
+++ b/tests/testthat/test_cluster_plotting.R
@@ -25,6 +25,7 @@ test_that("validation functions work properly in pca_plot", {
   expect_error(pca_plot(fluidigm, 1, num_clust=4),
                "object of class 'multiClust'")
   expect_error(pca_plot(fluidigm, f_clust, num_clust=-1), "num_clust")
+  expect_silent(pca_plot(fluidigm, f_clust, num_clust = 2:4))
 })
 
 


### PR DESCRIPTION
This pull request adds to `pca_plot` the ability to handle a vector of values being passed into `num_clust`. It displays separate plots of the data colorized for each of the values passed into `num_clust`. To do this, the `plot` function is no longer used in favor of `ggplot` and its `facet_wrap` function.
